### PR TITLE
Correct the spelling of Xcode in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 ###重要!
 
 #### SDK1.6.2
-1. xCode7.1 构建的sdk包
-2. 请使用xCode7.1进行编译
+1. Xcode7.1 构建的sdk包
+2. 请使用Xcode7.1进行编译
 
 #### SDK1.6.1
 1. 修复armv7s下,bitcode可能编译不过


### PR DESCRIPTION
This pull request corrects the spelling of **Xcode** :sweat_smile:
https://developer.apple.com/xcode/

Created with [`xcode-readme`](https://github.com/dkhamsing/xcode-readme).
